### PR TITLE
fix pathing so our app is served from public

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const Root = () => {
   return(
     <BrowserRouter>
       <div>
-        <Match exactly pattern='/public/' component={ App }/>
+        <Match exactly pattern='/' component={ App }/>
       </div>
     </BrowserRouter>
   )

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "App for tracking Friday activities",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --hot --inline",
+    "start": "webpack-dev-server --hot --inline --content-base ./public",
     "build": "webpack",
     "test": "mocha --require test/helpers/setup.js"
   },


### PR DESCRIPTION
## Purpose
This PR fixes a pathing issue where we were having to setup our router to look at the /public folder.  Now the app is served from the root so our routing is serving the app component on the '/' path.

## Approach
Looked through the webpack docs and followed steps found [Here](http://stackoverflow.com/questions/33382526/webpack-dev-server-serves-a-directory-list-instead-of-the-app-page)

## Open Questions and Pre-Merge TODOs
This PR is ready to merge pending code review.