### PR TITLE
require sass in index.js and add npm packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+require('./styles/main');
 import React from 'react';
 import { render } from 'react-dom';
 import { BrowserRouter, Match } from 'react-router';
@@ -13,4 +14,4 @@ const Root = () => {
   )
 }
 
-render(<Root/>, document.querySelector('#app'))
+render(<Root/>, document.getElementById('app'))

--- a/lib/styles/_body.scss
+++ b/lib/styles/_body.scss
@@ -1,0 +1,3 @@
+body {
+  background: #8de7b6;
+}

--- a/lib/styles/main.scss
+++ b/lib/styles/main.scss
@@ -1,0 +1,1 @@
+@import '_body';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "firebase": "^3.6.4",
     "firebase-tools": "^3.2.1",
     "node-sass": "^4.1.1",
+    "resolve-url-loader": "^1.6.1",
     "sass-loader": "^4.1.1",
+    "style-loader": "^0.13.1",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2"
   },


### PR DESCRIPTION
We needed to install the "style-loader" and "resolve-url-loader" npm packages in order to get our styling wired up correctly. The "resolve-url-loader" will come in handy when we have images since it directs the images relative to the .scss file.
[resolve-url-loader npm package](https://www.npmjs.com/package/resolve-url-loader)

After these were installed we could require the "main.scss" file in the "index.js" file. Now when you fire up the server the background should be a light green. 
