### PR TITLE
refactor out global variable, pass user to components like a good person

### DIFF
--- a/lib/allAdmins.js
+++ b/lib/allAdmins.js
@@ -1,5 +1,5 @@
 const allAdmins = [
-  'peterspringer829@gmail.cm',
+  'jeff.duke@gmail.cm'
 ];
 
 export default allAdmins;

--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -5,7 +5,7 @@ import { map } from 'lodash';
 import AdminSpike from './AdminSpike';
 import Spike from './Spike';
 
-const Admin = ({ spikes, createSpike, updateSpike, deleteSpike }) => {
+const Admin = ({ spikes, createSpike, updateSpike, deleteSpike, user }) => {
 
   let allSpikes = map(spikes, (spike) => {
     return <AdminSpike spike={spike} key={spike.key}
@@ -15,7 +15,7 @@ const Admin = ({ spikes, createSpike, updateSpike, deleteSpike }) => {
 
   return (
     <div>
-      <Spike createSpike={createSpike}/>
+      <Spike createSpike={createSpike} user={user}/>
       <h1>Spikes</h1>
       {allSpikes}
     </div>

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -6,7 +6,6 @@ import Spikes from './Spikes';
 import Header from './Header';
 import Admin from './Admin';
 import allAdmins from '../allAdmins';
-let firebaseUser = null;
 
 export default class App extends Component {
   constructor() {
@@ -20,10 +19,6 @@ export default class App extends Component {
   componentDidMount() {
     firebase.auth().onAuthStateChanged((newUser) => {
       this.newUser(newUser);
-
-      //temporary fix until we figure out how to access the firebase user inside of the scoped
-      //createSpike function
-      firebaseUser = newUser;
     });
     reference.limitToLast(100).on('value', (snapshot) => {
       const spikes = snapshot.val() || {};
@@ -37,7 +32,7 @@ export default class App extends Component {
     this.setState({ user: newUser });
   }
 
-  createSpike(e) {
+  createSpike(e, user) {
     e.preventDefault();
     let { title, description } = e.target;
     let spike = {
@@ -47,7 +42,7 @@ export default class App extends Component {
       appr: false,
       count: 0,
       createdAt: Date.now(),
-      user: firebaseUser.email
+      user: user.email
     };
     reference.push(spike);
     document.getElementById("proposalForm").reset()
@@ -79,6 +74,7 @@ export default class App extends Component {
           <Admin createSpike={this.createSpike} spikes={this.state.spikes}
             updateSpike={this.updateSpike}
             deleteSpike={this.deleteSpike}
+            user={this.state.user}
           />
         </div>
       )
@@ -92,6 +88,7 @@ export default class App extends Component {
             createSpike={this.createSpike}
             spikes={this.state.spikes}
             updateCount={this.updateCount}
+            user={this.state.user}
           />
         </div>
       )

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -2,7 +2,7 @@ import React from 'react';
 import firebase from '../firebase';
 import moment from 'moment';
 
-const Spike = ({ spike, createSpike, updateCount }, key, admin ) => {
+const Spike = ({ spike, createSpike, updateCount, user }, key, admin ) => {
   if (spike) {
     return (
       <div className="spike-card" key={key}>
@@ -17,7 +17,7 @@ const Spike = ({ spike, createSpike, updateCount }, key, admin ) => {
     )
   } else {
     return (
-      <form id='proposalForm' name='create-spike' onSubmit={(e)=>createSpike(e)}>
+      <form id='proposalForm' name='create-spike' onSubmit={ (e)=>createSpike(e, user) }>
         <input placeholder='title' name='title'/>
         <textarea placeholder='description' name='description'/>
         <input type='submit'/>

--- a/lib/components/Spikes.js
+++ b/lib/components/Spikes.js
@@ -4,7 +4,7 @@ import { map } from 'lodash'
 
 import Spike from './Spike';
 
-const Spikes = ({ spikes, createSpike, updateCount }) => {
+const Spikes = ({ spikes, createSpike, updateCount, user }) => {
   let allSpikes = map(spikes, (spike) => {
     if(spike.appr === true) {
       return <Spike spike={spike} key={spike.key} updateCount={updateCount} />
@@ -12,7 +12,7 @@ const Spikes = ({ spikes, createSpike, updateCount }) => {
   })
   return (
     <div>
-      <Spike createSpike={createSpike} />
+      <Spike createSpike={createSpike} user={user} />
       <h1>Spikes</h1>
       {allSpikes}
     </div>


### PR DESCRIPTION
## Purpose
This PR gets rid of the global firebase.user variable and instead passes the currently logged in user down to the create-spike component so that when a user or admin creates a new spike, their user info is available to that object.

## Approach
Worked through the code with Pete and looked for ways to refactor.

## Pre-merge todos:
None, this PR is ready to merge pending code review.