### PR TITLE
One user one vote per spike

### DIFF
--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -8,11 +8,14 @@ import Spike from './Spike';
 const Admin = ({ spikes, createSpike, updateSpike, deleteSpike, user }) => {
 
   let allSpikes = map(spikes, (spike) => {
-    return <AdminSpike spike={spike} key={spike.key}
+    return (
+      <AdminSpike spike={spike} 
+            key={spike.key}
             updateSpike={updateSpike}
-            deleteSpike={deleteSpike}/>
-  })
-
+            deleteSpike={deleteSpike}
+      />
+    )
+  });
   return (
     <div>
       <Spike createSpike={createSpike} user={user}/>

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -7,7 +7,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
     <div className="spike-card" key={key}>
       <h1>{spike.title}</h1>
       <h2>{spike.description}</h2>
-      <p>{spike.user}</p>
+      <p>{spike.createdBy}</p>
       <h3>{moment(spike.created_at).format("MM-DD-YYYY")}</h3>
         <input type='radio' name='location' value='GBank'
           onClick={(e)=>updateSpike(spike, 'location', e.target.value)}

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -42,7 +42,8 @@ export default class App extends Component {
       appr: false,
       count: 0,
       createdAt: Date.now(),
-      user: user.email
+      createdBy: user.email,
+      attendees: [user.email]
     };
     reference.push(spike);
     document.getElementById("proposalForm").reset()
@@ -57,9 +58,14 @@ export default class App extends Component {
     firebase.database().ref(`spikes/${spike.key}`).remove();
   }
 
-  updateCount(spike) {
-    spike['count'] = spike.count + 1;
-    firebase.database().ref(`spikes/${spike.key}`).update( spike );
+  updateCount(spike, user) {
+    if (!spike.attendees.includes(user.email)) {
+      spike.attendees.push(user.email);
+      firebase.database().ref(`spikes/${spike.key}`).update( spike );
+    }
+    else {
+      alert('you are already attending that spike!');
+    }
   }
 
   render() {

--- a/lib/components/Header.js
+++ b/lib/components/Header.js
@@ -5,13 +5,7 @@ import { signOut } from '../firebase';
 const Header = ({user}) => {
   return (
     <header >
-      <p>
-        Logged in as {' '}
-        <span className="LogInName">
-          {user.displayName}{' '}
-        </span>
-        ({user.email})
-      </p>
+        <pre>Logged in as {user.email} </pre> 
       <button onClick={() => signOut()}>Sign Out</button>
     </ header>
   )

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -10,9 +10,9 @@ const Spike = ({ spike, createSpike, updateCount, user }, key, admin ) => {
         <h2>{spike.description}</h2>
         <p>{moment(spike.createdAt).format("MM-DD-YYYY")}</p>
         <p>{spike.location}</p>
-        <p>{spike.user}</p>
-        <p>{spike.count}</p>
-        <button onClick={()=>updateCount(spike)}>Vote</button>
+        <p>{spike.createdBy}</p>
+        <p>{spike.attendees.length}</p>
+        <button onClick={()=>updateCount(spike, user)}>Vote</button>
       </div>
     )
   } else {

--- a/lib/components/Spikes.js
+++ b/lib/components/Spikes.js
@@ -7,7 +7,7 @@ import Spike from './Spike';
 const Spikes = ({ spikes, createSpike, updateCount, user }) => {
   let allSpikes = map(spikes, (spike) => {
     if(spike.appr === true) {
-      return <Spike spike={spike} key={spike.key} updateCount={updateCount} />
+      return <Spike spike={spike} key={spike.key} updateCount={updateCount} user={user}/>
     }
   })
   return (

--- a/lib/components/Spikes.js
+++ b/lib/components/Spikes.js
@@ -7,17 +7,14 @@ import Spike from './Spike';
 const Spikes = ({ spikes, createSpike, updateCount, user }) => {
   let allSpikes = map(spikes, (spike) => {
     if(spike.appr === true) {
-<<<<<<< HEAD
-      return <Spike spike={spike} key={spike.key} updateCount={updateCount} user={user}/>
-=======
       return (
         <Spike
           spike={spike}
           key={spike.key}
           updateCount={updateCount}
+          user={user}
         />
       )
->>>>>>> master
     }
   })
   return (


### PR DESCRIPTION
## Purpose
This PR updates our vote counting setup so that a user can only rsvp once to a spike session.  We now have an attendees list and we're displaying the count of how many unique attendees there are.  

## Approach
We created an attendees key on the spike when it's created, the creator is added as the first attendee by default.  When a user logs in and clicks on the vote button they're added to the attendees list.

## Pre-merge questions and todos:
none - this can be merged pending code review