### PR TITLE
Attendees list

### DIFF
--- a/lib/allAdmins.js
+++ b/lib/allAdmins.js
@@ -1,5 +1,5 @@
 const allAdmins = [
-  'jeff.duke@gmail.cm'
+  'jeff.duke@gmail.co'
 ];
 
 export default allAdmins;

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import firebase from '../firebase';
 import moment from 'moment';
+import uuid from 'uuid';
 
 const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
   return (
@@ -8,6 +9,15 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       <h1>{spike.title}</h1>
       <h2>{spike.description}</h2>
       <p>{spike.createdBy}</p>
+      <p>Attendees: </p>
+      <ul>
+        {spike.attendees ?
+          spike.attendees.map((attendee) => {
+            return <li key={new uuid()}>{attendee}</li>
+          })
+          : <p>No Attendees</p>
+        }
+      </ul>
       <h3>{moment(spike.created_at).format("MM-DD-YYYY")}</h3>
         <input
           type='radio'

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -43,7 +43,7 @@ export default class App extends Component {
       count: 0,
       createdAt: Date.now(),
       createdBy: user.email,
-      attendees: [user.email]
+      attendees: []
     };
     reference.push(spike);
     document.getElementById("proposalForm").reset();
@@ -59,14 +59,16 @@ export default class App extends Component {
   }
 
   updateCount(spike, user) {
-    if (spike.attendees.includes(user.email)) {
+    if (!spike.attendees) {
+      Object.assign(spike, {attendees: [user.email]});
+    }
+    else if (spike.attendees.includes(user.email)) {
       spike.attendees = spike.attendees.filter(attendee => attendee !== user.email);
-      firebase.database().ref(`spikes/${spike.key}`).update( spike );
     }
     else {
       spike.attendees.push(user.email);
-      firebase.database().ref(`spikes/${spike.key}`).update( spike );
     }
+    firebase.database().ref(`spikes/${spike.key}`).update( spike );
   }
 
   render() {

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -11,7 +11,7 @@ const Spike = ({ spike, createSpike, updateCount, user }, key, admin ) => {
         <p>{moment(spike.createdAt).format("MM-DD-YYYY")}</p>
         <p>{spike.location}</p>
         <p>{spike.createdBy}</p>
-        <p>{spike.attendees.length}</p>
+        <p>{spike.attendees ? spike.attendees.length : 0}</p>
         <button onClick={()=>updateCount(spike, user)}>Vote</button>
       </div>
     )

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "moment": "^2.17.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "react-router": "^4.0.0-alpha.3"
+    "react-router": "^4.0.0-alpha.3",
+    "uuid": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Purpose
This PR adds an attendees list to the admin view.  This allows an admin to see a full list of who will attend a spike, not just a count.  This PR also fixes a bug from the previous PR whereby the app would throw errors if the attendees count reached 0.

## Approach
The admin page now has a UL that checks to see if there is an attendees list for a spike, if so it renders list-items for each attendee.  
The bug with the empty attendee list is due to Firebase not allowing an empty array as a value on an object.  Had to add a check to see if there is an attendees key on the spike, if not it creates one and adds the user's email.  

## Pre-merge questions and Todos
None - this PR is ready to merge pending code review.