### PR TITLE
Update admin functionality and styling of admin page. Closes #24 and #20

### DIFF
--- a/lib/allAdmins.js
+++ b/lib/allAdmins.js
@@ -1,6 +1,9 @@
 let allAdmins = [
   'hellocaseycross@gmail.com',
-  // 'kerrd89@gmail.com'
+  'kerrd89@gmail.com',
+  'jeff.duke@gmail.com',
+  'kswanie21@gmail.com',
+  'peterspringer829@gmail.com',
 ];
 
 export default allAdmins;

--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -24,8 +24,8 @@ const Admin = ({ spikes, createSpike, updateSpike, deleteSpike, user }) => {
         createSpike={createSpike}
         user={user}
       />
-      <h1>Spikes</h1>
-      <div className="AllSpikes">
+      <h1 className="SpikesTitle">Spikes</h1>
+      <div className="AllSpikes AllAdminSpikes">
         {allSpikes}
       </div>
     </div>

--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -22,7 +22,7 @@ const Admin = ({ spikes, createSpike, updateSpike, deleteSpike,
   let allAdmins = map(admins, (admin, index) => {
     return (
       <p key={index}>{admin}
-        <button onClick={()=>removeAdmin(admin)}>X</button>
+        <button className="DeleteAdminButton" onClick={()=>removeAdmin(admin)}>X</button>
       </p>
     )
   })

--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -20,14 +20,16 @@ const Admin = ({ spikes, createSpike, updateSpike, deleteSpike,
   });
 
   let allAdmins = map(admins, (admin, index) => {
-    return <p key={index}>{admin}
-             <button onClick={()=>removeAdmin(admin)}>X</button>
-           </p>
+    return (
+      <p key={index}>{admin}
+        <button onClick={()=>removeAdmin(admin)}>X</button>
+      </p>
+    )
   })
 
   return (
     <div className="Admin">
-      {!showForm && <button onClick={() => toggleForm()}>Add Spike</button>}
+      {!showForm && <button className="AddSpikeButton" onClick={() => toggleForm()}>Add Spike</button>}
       {showForm && <Spike
         createSpike={createSpike}
         toggleForm={toggleForm}
@@ -36,7 +38,7 @@ const Admin = ({ spikes, createSpike, updateSpike, deleteSpike,
         {allAdmins}
         <form onSubmit={(e) => newAdmin(e)}>
           <input id="newAdmin" name='email' placeholder='email@email.com'/>
-          <input type="submit"/>
+          <input className="AdminSubmitButton" type="submit"/>
         </form>
       </div>
       <h1 className="SpikesTitle">Spikes</h1>

--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -25,7 +25,9 @@ const Admin = ({ spikes, createSpike, updateSpike, deleteSpike, user }) => {
         user={user}
       />
       <h1>Spikes</h1>
-      {allSpikes}
+      <div className="AllSpikes">
+        {allSpikes}
+      </div>
     </div>
   )
 }

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -5,10 +5,10 @@ import uuid from 'uuid';
 
 const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
   return (
-    <div className="spike-card" key={key}>
-      <h1>{spike.title}</h1>
-      <h2>{spike.description}</h2>
-      <p>{spike.createdBy}</p>
+    <div className="SpikeCard" key={key}>
+      <p>Spike Topic:  {spike.title}</p>
+      <p>Description:  {spike.description}</p>
+      <p>Added by:  {spike.createdBy}</p>
       <p>Attendees: </p>
       <ul>
         {spike.attendees ?
@@ -18,27 +18,30 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
           : <p>No Attendees</p>
         }
       </ul>
-      <h3>{moment(spike.created_at).format("MM-DD-YYYY")}</h3>
-        <input
-          type='radio'
-          name='location'
-          value='GBank'
-          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-        /> GBank
-        <input
-          type='radio'
-          name='location'
-          value='Gusto'
-          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-        /> Gusto
-        <input
-          type='radio'
-          name='location'
-          value='Blake'
-          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-        /> Blake
-      <button onClick={()=>updateSpike(spike, 'appr', true)}>Approve</button>
-      <button onClick={()=>deleteSpike(spike)}>Delete</button>
+      <h3>Date Submitted:  {moment(spike.created_at).format("MM-DD-YYYY")}</h3>
+        <form action="submit" className="location-form">
+          <p>Location: </p>
+          <input
+            type='radio'
+            name='location'
+            value='GBank'
+            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+          /> GBank
+          <input
+            type='radio'
+            name='location'
+            value='Gusto'
+            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+          /> Gusto
+          <input
+            type='radio'
+            name='location'
+            value='Blake'
+            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+          /> Blake
+          <button onClick={()=>updateSpike(spike, 'appr', true)}>Approve</button>
+          <button onClick={()=>deleteSpike(spike)}>Delete</button>
+        </form>
     </div>
   )
 }

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -17,7 +17,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
           spike.attendees.map((attendee) => {
             return <li className="attendee" key={new uuid()}>{attendee}</li>
           })
-          : <p>No Attendees Have Joined</p>
+          : <p><span>No Attendees Have Joined</span></p>
         }
       </ul>
       <p>

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -26,7 +26,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
         Spike Session Date:
         <span>Friday, January 6, 2017</span>
       </p>
-      <form action="submit" className="location-form">
+      <form className="location-form">
         <p>Location: </p>
         <input
           type='radio'
@@ -46,7 +46,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
           value='Blake'
           onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
         /> Blake
-        <button type="submit" onClick={()=>updateSpike(spike, 'appr', true)}>Approve</button>
+        <button onClick={()=>updateSpike(spike, 'appr', true)}>Approve</button>
         <button onClick={()=>deleteSpike(spike)}>Delete</button>
       </form>
     </div>

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -5,10 +5,11 @@ import uuid from 'uuid';
 
 const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
   return (
-    <div className="SpikeCard" key={key}>
-      <p>Spike Topic:  {spike.title}</p>
-      <p>Description:  {spike.description}</p>
-      <p>Added by:  {spike.createdBy}</p>
+    <div className="SpikeCard AdminSpikeCard" key={key}>
+      <p>Spike Topic:  <br/> <span>{spike.title}</span></p>
+      <p>Description: <br/> <span>{spike.description}</span></p>
+      <p>Added by:  <span>{spike.createdBy}</span></p>
+      <p>Session Leaders:  <span>Posse/Student Name(s)</span></p>
       <p>Attendees: </p>
       <ul>
         {spike.attendees ?
@@ -18,30 +19,36 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
           : <p>No Attendees</p>
         }
       </ul>
-      <h3>Date Submitted:  {moment(spike.created_at).format("MM-DD-YYYY")}</h3>
-        <form action="submit" className="location-form">
-          <p>Location: </p>
-          <input
-            type='radio'
-            name='location'
-            value='GBank'
-            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-          /> GBank
-          <input
-            type='radio'
-            name='location'
-            value='Gusto'
-            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-          /> Gusto
-          <input
-            type='radio'
-            name='location'
-            value='Blake'
-            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-          /> Blake
-          <button onClick={()=>updateSpike(spike, 'appr', true)}>Approve</button>
-          <button onClick={()=>deleteSpike(spike)}>Delete</button>
-        </form>
+      <p>
+        Date Submitted:  <span>{moment(spike.created_at).format("MM-DD-YYYY")}</span>
+      </p>
+      <p>
+        Spike Session Date:
+        <span>Friday, January 6, 2017</span>
+      </p>
+      <form action="submit" className="location-form">
+        <p>Location: </p>
+        <input
+          type='radio'
+          name='location'
+          value='GBank'
+          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+        /> GBank
+        <input
+          type='radio'
+          name='location'
+          value='Gusto'
+          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+        /> Gusto
+        <input
+          type='radio'
+          name='location'
+          value='Blake'
+          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+        /> Blake
+        <button type="submit" onClick={()=>updateSpike(spike, 'appr', true)}>Approve</button>
+        <button onClick={()=>deleteSpike(spike)}>Delete</button>
+      </form>
     </div>
   )
 }

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -15,7 +15,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       <ul>
         {spike.attendees ?
           spike.attendees.map((attendee) => {
-            return <li key={new uuid()}>{attendee}</li>
+            return <li className="attendee" key={new uuid()}>{attendee}</li>
           })
           : <p>No Attendees Have Joined</p>
         }
@@ -28,35 +28,40 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
         <span>  01-06-2017</span>
       </p>
       <form className="location-form">
-        <p>Location: </p>
-        <input
-          type='radio'
-          name='location'
-          value='GBank'
-          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-        /> GBank
-        <input
-          type='radio'
-          name='location'
-          value='Gusto'
-          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-        /> Gusto
-        <input
-          type='radio'
-          name='location'
-          value='Blake'
-          onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
-        /> Blake
-
+        <p className="location-assignment">
+          Assigned Location:  {spike.location}
+        </p>
+        <section className="location-input-container">
+          <input
+            type='radio'
+            name='location'
+            value='GBank'
+            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+          /> GBank
+          <input
+            type='radio'
+            name='location'
+            value='Gusto'
+            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+          /> Gusto
+          <input
+            type='radio'
+            name='location'
+            value='Blake'
+            onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
+          /> Blake
+        </section>
         <button
           className="ApproveButton"
           onClick={()=>updateSpike(spike, 'appr', true)}
-          disabled={spike.location === ''}
-        >
+          disabled={spike.location === ''}>
           Approve
         </button>
-
-        <button onClick={()=>deleteSpike(spike)}>Delete</button>
+        <button
+          className="DeleteButton"
+          onClick={()=>deleteSpike(spike)}>
+          Delete
+        </button>
       </form>
     </div>
   )

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -29,7 +29,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       </p>
       <form className="location-form">
         <p className="location-assignment">
-          Assigned Location:  {spike.location}
+          Assigned Location:  <span>{spike.location}</span>
         </p>
         <section className="location-input-container">
           <input

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import uuid from 'uuid';
 
 const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
+
   return (
     <div className="SpikeCard AdminSpikeCard" key={key}>
       <p>Spike Topic:  <br/> <span>{spike.title}</span></p>
@@ -16,7 +17,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
           spike.attendees.map((attendee) => {
             return <li key={new uuid()}>{attendee}</li>
           })
-          : <p>No Attendees</p>
+          : <p>No Attendees Have Joined</p>
         }
       </ul>
       <p>
@@ -24,7 +25,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       </p>
       <p>
         Spike Session Date:
-        <span>Friday, January 6, 2017</span>
+        <span>  01-06-2017</span>
       </p>
       <form className="location-form">
         <p>Location: </p>
@@ -46,7 +47,15 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
           value='Blake'
           onClick={(e)=>updateSpike(spike, 'location', e.target.value)}
         /> Blake
-        <button onClick={()=>updateSpike(spike, 'appr', true)}>Approve</button>
+
+        <button
+          className="ApproveButton"
+          onClick={()=>updateSpike(spike, 'appr', true)}
+          disabled={spike.location === ''}
+        >
+          Approve
+        </button>
+
         <button onClick={()=>deleteSpike(spike)}>Delete</button>
       </form>
     </div>

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -49,7 +49,7 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm }, key, admin ) => 
                   toggleForm(e)
                 }}
               />
-            </div>  
+            </div>
           </form>
         </div>
       </div>
@@ -57,4 +57,4 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm }, key, admin ) => 
   }
 }
 
-export default Spike
+export default Spike;

--- a/lib/components/Spikes.js
+++ b/lib/components/Spikes.js
@@ -29,4 +29,4 @@ const Spikes = ({ spikes, createSpike, updateCount, showForm, toggleForm }) => {
   )
 }
 
-export default Spikes
+export default Spikes;

--- a/lib/styles/main.scss
+++ b/lib/styles/main.scss
@@ -6,3 +6,4 @@
 @import 'partials/_header';
 @import 'partials/_spike';
 @import 'partials/_proposal-form';
+@import 'partials/_admin-spike';

--- a/lib/styles/modules/_mixins.scss
+++ b/lib/styles/modules/_mixins.scss
@@ -1,13 +1,15 @@
-@mixin button-format {
-  background: $teal-accent;
-  border: none;
+@mixin button-format ($color1, $color2) {
+  background: $color1;
   border-radius: 5px;
+  border: none;
   box-shadow: 0px 2px 4px 0px rgba(0,0,0,0.50);
-  color: #FFF;
+  color: $color2;
+  font-size: 20px;
+  margin: 0 auto;
   outline: none;
   transition: 0.3s;
   &:hover {
-    background: darken($teal-accent, 5%);
+    background: darken($color1, 5%);
     cursor: pointer;
     transition: 0.3s;
   }

--- a/lib/styles/partials/_admin-spike.scss
+++ b/lib/styles/partials/_admin-spike.scss
@@ -1,0 +1,13 @@
+.AdminSpikeCard {
+  background: $teal-accent;
+  border: 1px solid #000;
+}
+
+.AdminSpikeCard p {
+  color: #000;
+}
+
+.AdminSpikeCard span {
+  color: $dark-gray-text-color;
+  font-weight: lighter;
+}

--- a/lib/styles/partials/_admin-spike.scss
+++ b/lib/styles/partials/_admin-spike.scss
@@ -1,13 +1,41 @@
 .AdminSpikeCard {
-  background: $teal-accent;
-  border: 1px solid #000;
+  background: transparentize($teal-accent, .1);
+  border: 1px solid $light-gray-text-color;
+  p {
+    color: #000;
+    margin-bottom: 5px;
+  }
+  span {
+    color: #FFF;
+  }
 }
 
-.AdminSpikeCard p {
-  color: #000;
+.attendee {
+  color: #FFF;
+  margin-bottom: 5px;
 }
 
-.AdminSpikeCard span {
-  color: $dark-gray-text-color;
-  font-weight: lighter;
+.location-form {
+  border: 1px solid black;
+  margin: 0 auto;
+  margin-top: auto;
+  padding: 10px;
+  width: 97%;
+  input {
+    margin: 15px;
+  }
+}
+
+.ApproveButton,
+.DeleteButton {
+  @include button-format(#FFF, $teal-accent);
+  margin-bottom: 5px;
+  width: 150px;
+}
+
+.AddSpikeButton,
+.AdminSubmitButton {
+  @include button-format($teal-accent, #FFF);
+  margin: 10px;
+  width: 150px;
 }

--- a/lib/styles/partials/_admin-spike.scss
+++ b/lib/styles/partials/_admin-spike.scss
@@ -1,6 +1,6 @@
 .AdminSpikeCard {
   background: transparentize($teal-accent, .1);
-  border: 1px solid $light-gray-text-color;
+  border: 1px solid $dark-gray-text-color;
   p {
     color: #000;
     margin-bottom: 5px;
@@ -24,6 +24,13 @@
   input {
     margin: 15px;
   }
+}
+
+.DeleteAdminButton {
+  @include button-format($teal-accent, #FFF);
+  border-radius: 50%;
+  font-size: 14px;
+  margin-left: 5px;
 }
 
 .ApproveButton,

--- a/lib/styles/partials/_header.scss
+++ b/lib/styles/partials/_header.scss
@@ -40,9 +40,10 @@ header {
 }
 
 .SignOut {
-  @include button-format;
+  @include button-format($teal-accent, #FFF);
   float: right;
   font-size: 14px;
+  width: 75px;
 }
 
 @media screen and (max-width: 420px) {

--- a/lib/styles/partials/_proposal-form.scss
+++ b/lib/styles/partials/_proposal-form.scss
@@ -43,7 +43,7 @@ textarea {
 }
 
 .SubmitButton, .CancelButton {
-  @include button-format;
+  @include button-format($teal-accent, #FFF);
   font-size: 16px;
   margin: 15px 5px;
   text-align: center;

--- a/lib/styles/partials/_sign-in.scss
+++ b/lib/styles/partials/_sign-in.scss
@@ -8,7 +8,7 @@
 }
 
 #LogInButton {
-  @include button-format;
+  @include button-format($teal-accent, #FFF);
   font-size: 26px;
   margin-top: 40px;
   padding: 8px;

--- a/lib/styles/partials/_spike.scss
+++ b/lib/styles/partials/_spike.scss
@@ -27,11 +27,9 @@
 }
 
 .JoinButton {
-  @include button-format;
-  font-size: 20px;
-  margin: 0 auto;
-  width: 70px;
+  @include button-format($teal-accent, #FFF);
   margin-top: auto;
+  width: 70px;
 }
 
 @media screen and (max-width: 780px) {


### PR DESCRIPTION
Ignore the comment about ignoring the PR.  That was something I was trying to do yesterday and didn't want anyone to think it was something ready for production.  I cannot seem to delete that commit.  This still needs review and approval.

Purpose:  We needed to enable the user to be able to check radio buttons for more than one  spike card on the admin page.  Also needed to disable the approve button if spike had already been approved.  We needed descriptors on all of the spike details as there were none to explain what each field was.  Throughout the process of this I also incorporated a similar styling format as the user page.  Because of this, I made some adjustments to the mixins and the buttons across all components so that button styling was consistent across the app. 

Execution:  See commit messages for history of execution.