### PR TITLE
multiple attendees now rendering again

### DIFF
--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -12,8 +12,8 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       <p>Attendees: </p>
       <ul>
         {spike.attendees ?
-          spike.attendees.map((attendee) => {
-            return <li key={new uuid()}>{attendee}</li>
+          spike.attendees.map((attendee, index) => {
+            return <li key={index}>{attendee}</li>
           })
           : <p>No Attendees</p>
         }

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import firebase from '../firebase';
 import moment from 'moment';
-import uuid from 'uuid';
 
 const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
   return (

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "moment": "^2.17.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "react-router": "^4.0.0-alpha.3",
-    "uuid": "^3.0.1"
+    "react-router": "^4.0.0-alpha.3"
   }
 }


### PR DESCRIPTION
this solves the bug of multiple attendees not rendering.  the issue was a uuid package which we had all not npm installed.  we bypass this issue by using the index of the attendees as a primary key and remove the uuid dependency.