### PR TITLE
add a date field to schedule the spike - Closes #36, Closes #38, Closes #50

### DIFF
--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -3,7 +3,6 @@ import firebase from '../firebase';
 import moment from 'moment';
 
 const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
-
   return (
     <div className="SpikeCard AdminSpikeCard" key={key}>
       <p>Spike Topic:  <br/> <span>{spike.title}</span></p>
@@ -24,7 +23,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       </p>
       <p>
         Spike Session Date:
-        <span>  01-06-2017</span>
+        <span>  {moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
       </p>
       <form className="location-form">
         <p className="location-assignment">
@@ -52,13 +51,19 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
         </section>
         <button
           className="ApproveButton"
-          onClick={()=>updateSpike(spike, 'appr', true)}
+          onClick={(e)=> {
+            e.preventDefault();
+            updateSpike(spike, 'appr', true);
+          }}
           disabled={spike.location === ''}>
           Approve
         </button>
         <button
           className="DeleteButton"
-          onClick={()=>deleteSpike(spike)}>
+          onClick={(e)=> {
+            e.preventDefault();
+            deleteSpike(spike)
+          }}>
           Delete
         </button>
       </form>

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -58,8 +58,7 @@ export default class App extends Component {
   createSpike(e) {
     e.preventDefault();
     const user = this.state.user;
-    let { title, description } = e.target;
-    let spikeDate = e.target.spikeDate.value;
+    let { title, description, spikeDate } = e.target;
     let spike = {
       title: title.value,
       description: description.value,
@@ -69,7 +68,7 @@ export default class App extends Component {
       createdAt: Date.now(),
       createdBy: user.email,
       attendees: [],
-      spikeDate: spikeDate,
+      spikeDate: spikeDate.value,
     };
     reference.push(spike);
     document.getElementById('ProposalForm').reset();

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -59,6 +59,7 @@ export default class App extends Component {
     e.preventDefault();
     const user = this.state.user;
     let { title, description } = e.target;
+    let spikeDate = e.target.spikeDate.value;
     let spike = {
       title: title.value,
       description: description.value,
@@ -67,7 +68,8 @@ export default class App extends Component {
       count: 0,
       createdAt: Date.now(),
       createdBy: user.email,
-      attendees: []
+      attendees: [],
+      spikeDate: spikeDate,
     };
     reference.push(spike);
     document.getElementById('ProposalForm').reset();

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -9,7 +9,10 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm, user }, key, admin
       <div className='SpikeCard' key={key}>
         <p>Title: <span>{spike.title}</span></p>
         <p>Description: <span>{spike.description}</span></p>
-        <p>Date: <span>{moment(spike.createdAt).format('MM-DD-YYYY')}</span></p>
+        <p>
+        Spike Session Date:
+          <span>  {moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
+        </p>
         <p>Location: <span>{spike.location}</span></p>
         <p>Led by: <span>{spike.createdBy}</span></p>
         <p>Attendees: <span>{spike.attendees ? spike.attendees.length : 0}</span></p>
@@ -40,6 +43,13 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm, user }, key, admin
               placeholder='Topic Title'
               name='title'
             />
+            <label className='SpikeDate' htmlFor='date-of-spike'>Date of Spike
+            <input
+              className='SpikeDatePicker'
+              type='date'
+              name='spikeDate'
+            />
+            </label>
             <textarea
               placeholder='Description'
               name='description'

--- a/lib/styles/partials/_proposal-form.scss
+++ b/lib/styles/partials/_proposal-form.scss
@@ -31,6 +31,16 @@ form {
   text-align: center;
 }
 
+.SpikeDate {
+  color: #FFF;
+  font-size: 24px;
+  font-family: sans-serif;
+}
+
+.SpikeDatePicker {
+  margin-left: 20px;
+}
+
 input {
   @include input-fields;
   margin: 15px 0;


### PR DESCRIPTION
## Purpose
This PR adds a new date field to the spike creation form that lets the creator pick which date they'd like the spike scheduled for.  This will allow a creator to schedule a spike for weeks into the future.

PR also fixes a couple bugs where the buttons/forms were reloading the page on click and this was appending information to the url.  by using `e.preventDefault()` this prevents the default submit and fixes the bug of the URL changing.

## Approach
Added a new date field to the spike form with a type of date.  Added a new key-value pair to the spike object before it goes to the database.  

## Pre merge questions and TODOs:
None, this PR is ready to merge pending code review.