### PR TITLE
Fixed word wrap issue so words don't break in the middle - Closes #39

### DIFF
--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -11,7 +11,7 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm, user }, key, admin
         <p>Description: <span>{spike.description}</span></p>
         <p>
         Spike Session Date:
-          <span>{moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
+          <span>  {moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
         </p>
         <p>Location: <span>{spike.location}</span></p>
         <p>Led by: <span>{spike.createdBy}</span></p>

--- a/lib/styles/partials/_spike.scss
+++ b/lib/styles/partials/_spike.scss
@@ -23,6 +23,7 @@
   padding: 15px;
   width: 350px;
   word-wrap: normal;
+  word-break: normal;
 }
 
 .JoinButton {

--- a/lib/styles/partials/_spike.scss
+++ b/lib/styles/partials/_spike.scss
@@ -22,7 +22,6 @@
   overflow-wrap: normal;
   padding: 15px;
   width: 350px;
-  // word-break: break-all;
   word-wrap: normal;
 }
 

--- a/lib/styles/partials/_spike.scss
+++ b/lib/styles/partials/_spike.scss
@@ -19,11 +19,11 @@
   display: flex;
   flex-direction: column;
   margin: 10px;
-  overflow-wrap: break-word;
+  overflow-wrap: normal;
   padding: 15px;
   width: 350px;
-  word-break: break-all;
-  word-wrap: break-word;
+  // word-break: break-all;
+  word-wrap: normal;
 }
 
 .JoinButton {


### PR DESCRIPTION
## Purpose
This PR fixes a UI issue where words were breaking inside the spike card and admin spike card containers.

## Approach
I changed the overflow-wrap and word-wrap CSS properties to "normal" instead of "break-word".  I also removed the word-break property as it was not needed.

## Pre merge questions and TODOs:
None, this PR is ready to merge pending code review.