### PR TITLE
Added input and display fields for spike hosts and notes for staff - Closes #27

### DIFF
--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -25,10 +25,14 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
         Spike Session Date:
         <span>  {moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
       </p>
-      <p>Approval Status:
-        {spike.appr ? <span> Approved</span> : <span> Pending</span>}
+      <p>
+        Notes for Staff:
+        <span>  {spike.notes}</span>
       </p>
       <form className="location-form">
+        <p>Approval Status:
+          {spike.appr ? <span> Approved</span> : <span> Pending</span>}
+        </p>
         <p className="location-assignment">
           Assigned Location:  <span>{spike.location}</span>
         </p>

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -8,7 +8,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       <p>Spike Topic:  <br/> <span>{spike.title}</span></p>
       <p>Description: <br/> <span>{spike.description}</span></p>
       <p>Added by:  <span>{spike.createdBy}</span></p>
-      <p>Session Leaders:  <span>Posse/Student Name(s)</span></p>
+      <p>Spike Hosts:  <span>{spike.hosts}</span></p>
       <p>Attendees: </p>
       <ul>
         {spike.attendees ?

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -7,7 +7,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
     <section className="SpikeCard AdminSpikeCard" key={key}>
       <p>Spike Topic:  <br/> <span>{spike.title}</span></p>
       <p>Description: <br/> <span>{spike.description}</span></p>
-      <p>Added by:  <span>{spike.createdBy}</span></p>
+      <p>Created by:  <span>{spike.createdBy}</span></p>
       <p>Spike Hosts:  <span>{spike.hosts}</span></p>
       <p>Attendees: </p>
       <ul>

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -31,7 +31,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike }, key ) => {
       </p>
       <form className="location-form">
         <p>Approval Status:
-          <span>{spike.appr ?  Approved : Pending}</span>
+          <span>{spike.appr ?  'Approved' : 'Pending'}</span>
         </p>
         <p className="location-assignment">
           Assigned Location:  <span>{spike.location}</span>

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -76,8 +76,8 @@ export default class App extends Component {
         createdBy: user.email,
         hosts: hosts.value,
         attendees: [],
-        notes: notes.value,
         spikeDate: new Date(spikeDate.value).getTime(),
+        notes: notes.value
       };
       reference.push(spike);
       document.getElementById('ProposalForm').reset();

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -58,7 +58,7 @@ export default class App extends Component {
   createSpike(e) {
     e.preventDefault();
     const user = this.state.user;
-    let { title, description, spikeDate, hosts } = e.target;
+    let { title, description, spikeDate, hosts, notes } = e.target;
     if (title.value && description.value && spikeDate.value) {
       let spike = {
         title: title.value,
@@ -71,6 +71,7 @@ export default class App extends Component {
         hosts: hosts.value,
         attendees: [],
         spikeDate: spikeDate.value,
+        notes: notes.value
       };
       reference.push(spike);
       document.getElementById('ProposalForm').reset();

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -58,7 +58,7 @@ export default class App extends Component {
   createSpike(e) {
     e.preventDefault();
     const user = this.state.user;
-    let { title, description, spikeDate } = e.target;
+    let { title, description, spikeDate, hosts } = e.target;
     if (title.value && description.value && spikeDate.value) {
       let spike = {
         title: title.value,
@@ -68,6 +68,7 @@ export default class App extends Component {
         count: 0,
         createdAt: Date.now(),
         createdBy: user.email,
+        hosts: hosts.value,
         attendees: [],
         spikeDate: spikeDate.value,
       };

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -14,7 +14,8 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm, user }, key, admin
           <span>{moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
         </p>
         <p>Location: <span>{spike.location}</span></p>
-        <p>Led by: <span>{spike.createdBy}</span></p>
+        <p>Created by: <span>{spike.createdBy}</span></p>
+        <p>Spike Hosts: <span>{spike.hosts}</span></p>
         <p>Attendees: <span>{spike.attendees ? spike.attendees.length : 0}</span></p>
         <button
           id='join'
@@ -42,6 +43,10 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm, user }, key, admin
             <input
               placeholder='Spike Title'
               name='title'
+            />
+            <input
+              placeholder='Spike Hosts'
+              name='hosts'
             />
             <textarea
               placeholder='Description'

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -14,7 +14,6 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm, user }, key, admin
           <span>  {moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
         </p>
         <p>Location: <span>{spike.location}</span></p>
-        <p>Created by: <span>{spike.createdBy}</span></p>
         <p>Spike Hosts: <span>{spike.hosts}</span></p>
         <p>Attendees: <span>{spike.attendees ? spike.attendees.length : 0}</span></p>
         <button
@@ -51,6 +50,10 @@ const Spike = ({ spike, createSpike, updateCount, toggleForm, user }, key, admin
             <textarea
               placeholder='Description'
               name='description'
+            />
+            <textarea
+              placeholder='Notes for Staff'
+              name='notes'
             />
             <label className='SpikeDate' htmlFor='date-of-spike'>Date of Spike:
             <input

--- a/lib/styles/partials/_proposal-form.scss
+++ b/lib/styles/partials/_proposal-form.scss
@@ -36,12 +36,13 @@ form {
 
 input {
   @include input-fields;
-  margin: 15px 0;
+  margin: 10px 0;
 }
 
 textarea {
   @include input-fields;
-  height: 100px;
+  height: 80px;
+  margin: 15px 0;
   resize: none;
 }
 
@@ -50,6 +51,7 @@ input[type=date] {
 }
 
 .SpikeDatePicker {
+  height: 25px;
   margin-left: 10px;
 }
 


### PR DESCRIPTION
## Purpose
This PR adds the ability for user to identify which students and/or posses are hosting the spike session.  It also enables the user to add notes for the staff about any extra needs they may have for the session.  Spike hosts is now displayed on both UI and Admin interface.  Notes for staff is only rendered on Admin page.

## Approach
The implementation was pretty straightforward as described in the purpose. I also moved the "approval status" into the location container as it made more sense that all of the admin-related activities were in one section.  I also updated the styling of the spike form to reflect the added fields.

## Pre merge questions and TODOs:
None, this PR is ready to merge pending code review.