### PR TITLE
Limit to attending 1 session at a time -- Closes # 47

### DIFF
--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -14,7 +14,8 @@ export default class App extends Component {
       user: null,
       spikes: [],
       admins: [],
-      showForm: false
+      showForm: false,
+      attending: null
     };
   }
 
@@ -27,6 +28,7 @@ export default class App extends Component {
       this.setState({
         spikes: map(spikes, (val, key) => extend(val, { key }))
       });
+      this.setAttending();
     });
     adminReference.limitToLast(100).on('value', (snapshot) => {
       admins = snapshot.val() || {};
@@ -35,6 +37,30 @@ export default class App extends Component {
       });
       admins = invert(admins);
     });
+  }
+
+  setAttending() {
+    const {spikes, user} = this.state;
+    spikes.map((spike) => {
+      if (spike.attendees && spike.attendees.indexOf(user.email) !== -1) {
+        this.updateAttending(spike);
+      }
+    });
+  }
+
+  updateAttending(spike) {
+    if (this.state.attending) {
+      const oldSpike = this.state.attending;
+      const newSpike = spike;
+      console.log('you are attending: ', this.state.attending);
+      console.log('old spike: ', oldSpike);
+      this.setState({ attending: newSpike});
+    }
+    else {
+      this.setState({ attending: spike });
+    }
+    
+    console.log('you are attending: ', this.state.attending);
   }
 
   newUser(newUser) {

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -50,17 +50,27 @@ export default class App extends Component {
 
   updateAttending(spike) {
     if (this.state.attending) {
-      const oldSpike = this.state.attending;
-      const newSpike = spike;
-      console.log('you are attending: ', this.state.attending);
-      console.log('old spike: ', oldSpike);
-      this.setState({ attending: newSpike});
+      this.leaveSpike(this.state.attending);
+    }
+    spike ? this.setState({ attending: spike }) : this.setState({ attending: null });
+  }
+
+  updateCount(spike) {
+    const user = this.state.user;
+    if (!spike.attendees) {
+      let newSpike = Object.assign(spike, {attendees: [user.email]});
+      this.joinSpike(newSpike);
+      this.updateAttending(newSpike);
+    }
+    else if (spike.attendees.includes(user.email)) {
+      this.leaveSpike(spike);
+      this.updateAttending();
     }
     else {
-      this.setState({ attending: spike });
+      spike.attendees.push(user.email);
+      this.joinSpike(spike);
+      this.updateAttending(spike);
     }
-    
-    console.log('you are attending: ', this.state.attending);
   }
 
   newUser(newUser) {
@@ -113,17 +123,13 @@ export default class App extends Component {
     firebase.database().ref(`spikes/${spike.key}`).remove();
   }
 
-  updateCount(spike) {
+  joinSpike(spike) {
+    firebase.database().ref(`spikes/${spike.key}`).update( spike );
+  }
+
+  leaveSpike(spike) {
     const user = this.state.user;
-    if (!spike.attendees) {
-      Object.assign(spike, {attendees: [user.email]});
-    }
-    else if (spike.attendees.includes(user.email)) {
-      spike.attendees = spike.attendees.filter(attendee => attendee !== user.email);
-    }
-    else {
-      spike.attendees.push(user.email);
-    }
+    spike.attendees = spike.attendees.filter(attendee => attendee !== user.email);
     firebase.database().ref(`spikes/${spike.key}`).update( spike );
   }
 


### PR DESCRIPTION
## Purpose
This PR changes functionality so that a user can only RSVP to one session at a time.  I've added an 'attending' field to our state.  When App is mounted, the spikes are mapped through and if the user is set to attend a session that session is put in state.  Any time a user joins a state the function checks to see if they're already attending a spike, if so the user is removed from that spike before they are added to the new spike.  If a user leaves a spike they've joined, attending is set to null.  

![Functionality gif](http://g.recordit.co/5RtOLSvbUn.gif)

## Approach
I broke out our functions a bit.  I've added a `joinSpike` and `leaveSpike` method, a `setAttending` method for when the app is first loaded and an `updateAttending` method that's called when a user joins or leaves a session.  This sets us up for some cool UI features.  We could render a separate card on the page for the session that the user has joined so they see that more prominently.  We can add some UI feedback to inform a user that they've successfully joined a spike or have left a spike etc. 

## Pre Merge TODOs
None, this PR is ready to merge pending code review. 