### PR TITLE
Sanitize input closes #68

### DIFF
--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -150,9 +150,9 @@ export default class App extends Component {
 
   sanitizeInput(input) {
     return input.replace(/<script[^>]*?>.*?<\/script>/gi, '')
-      					.replace(/<[\/\!]*?[^<>]*?>/gi, '')
-      					.replace(/<style[^>]*?>.*?<\/style>/gi, '')
-      					.replace(/<![\s\S]*?--[ \t\n\r]*>/gi, '');
+			.replace(/<[\/\!]*?[^<>]*?>/gi, '')
+			.replace(/<style[^>]*?>.*?<\/style>/gi, '')
+			.replace(/<![\s\S]*?--[ \t\n\r]*>/gi, '');
   }
 
   render() {

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -103,17 +103,17 @@ export default class App extends Component {
     let { title, description, spikeDate, hosts, notes } = e.target;
     if (title.value && description.value && spikeDate.value) {
       let spike = {
-        title: title.value,
-        description: description.value,
+        title: this.sanitizeInput(title.value),
+        description: this.sanitizeInput(description.value),
         location: '',
         appr: false,
         count: 0,
         createdAt: Date.now(),
-        createdBy: user.email,
-        hosts: hosts.value,
+        createdBy: this.sanitizeInput(user.email),
+        hosts: this.sanitizeInput(hosts.value),
         attendees: [],
         spikeDate: new Date(spikeDate.value).getTime(),
-        notes: notes.value
+        notes: this.sanitizeInput(notes.value)
       };
       reference.push(spike);
       document.getElementById('ProposalForm').reset();
@@ -146,6 +146,13 @@ export default class App extends Component {
     return map(dates, (date, index) => {
       return <option key={index} value={date}>{moment(date).format('MM-DD-YYYY')}</option>
     })
+  }
+
+  sanitizeInput(input) {
+    return input.replace(/<script[^>]*?>.*?<\/script>/gi, '')
+      					.replace(/<[\/\!]*?[^<>]*?>/gi, '')
+      					.replace(/<style[^>]*?>.*?<\/style>/gi, '')
+      					.replace(/<![\s\S]*?--[ \t\n\r]*>/gi, '');
   }
 
   render() {


### PR DESCRIPTION
The spacing looks off here on github, but input sanitization appears to be working.

My approach:
I found a blog on the subject and sent the reg-ex function from that to alex to ask for his opinion.  He suggested we look into sanitize-html, but provided a functional alternative as well.

I tried a npm module called 'sanitize-html', but there were peer dependencies which were causing issues. 

The function I found on the aforementioned blog worked for rendering traditional html, but doesn't work for react (replacing symbols with their text equivalent).

Long story short, I am using the function alex provided and it appears to do the job.  We still need to validate email though seperately on both the newAdmin side and the newSpike side.
