### PR TITLE
Only current spikes being imported, spikes older than 1 year are deleted

### DIFF
--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -28,9 +28,14 @@ export default class App extends Component {
     });
 
     reference.limitToLast(100).on('value', (snapshot) => {
-      const spikes = snapshot.val() || {};
+      let spikes = snapshot.val() || {};
+      let currentSpikes = map(spikes, (spike) => {
+        if (spike.spikeDate > Date.now() - (1000*60*60*24)) {
+          return spike;
+        }
+      });
       this.setState({
-        spikes: map(spikes, (val, key) => extend(val, { key }))
+        spikes: map(currentSpikes, (val, key) => extend(val, { key }))
       });
       this.setAttending();
     });

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -6,7 +6,7 @@ import SignIn from './SignIn';
 import Spikes from './Spikes';
 import Header from './Header';
 import Admin from './Admin';
-import GuestSpeaker from './GuestSpeaker'
+import GuestSpeaker from './GuestSpeaker';
 let admins = {};
 
 export default class App extends Component {
@@ -28,10 +28,15 @@ export default class App extends Component {
     });
 
     reference.limitToLast(100).on('value', (snapshot) => {
+      let oneDay = 1000*60*60*24;
+      let oneYear = 1000*60*60*24*365;
+
       let spikes = snapshot.val() || {};
       let currentSpikes = map(spikes, (spike) => {
-        if (spike.spikeDate > Date.now() - (1000*60*60*24)) {
+        if (spike.spikeDate > Date.now() - oneDay) {
           return spike;
+        } else if (spike.spikeDate < Date.now() - oneYear) {
+          this.deleteSpike(spike);
         }
       });
       this.setState({


### PR DESCRIPTION
This spike solves the issue of the earliest date available showing, rather than the nearest spike.  Old spikes are being excluded when we set the firebase data to state, spikes older than one year are being deleted at the same time.