### PR TITLE
Update UI to show your pending spikes -- Closes #69, Closes #97

### DIFF
--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -47,6 +47,8 @@ export default class Admin extends Component {
               updateSpike={this.props.updateSpike}
               deleteSpike={this.props.deleteSpike}
               attending={this.props.attending}
+              admins={this.props.admins}
+              user={this.props.user}
             />)
           }
         }

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -53,7 +53,7 @@ const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike
       <p>
         Notes for Staff:<span>{spike.notes}</span>
       </p>
-      {admins && user && admins.includes(user.email) ? 
+      {admins && user && admins.includes(user.email) && 
       <section className='AdminInputs'>
         <p>Location:
           <select
@@ -88,7 +88,7 @@ const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike
           </select>
         </p>
       </section>
-      : f => f}
+      }
       <button
         className='DeleteButton'
         onClick={(e)=> {

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -3,7 +3,7 @@ import firebase from '../firebase';
 import moment from 'moment';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
-const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike, attending }, key ) => {
+const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike, attending }, key ) => {
   return (
     <section
       className={spike.appr ? 'ApprovedSpike' : 'SpikeCard AdminSpikeCard'}
@@ -52,6 +52,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike, attending },
       <p>
         Notes for Staff:<span>{spike.notes}</span>
       </p>
+      {admins && user && admins.includes(user.email) ? 
       <section className='AdminInputs'>
         <p>Location:
           <select
@@ -86,6 +87,7 @@ const AdminSpike = ({ spike, createSpike, updateSpike, deleteSpike, attending },
           </select>
         </p>
       </section>
+      : f => f}
       <button
         className='DeleteButton'
         onClick={(e)=> {

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -3,7 +3,7 @@ import firebase from '../firebase';
 import moment from 'moment';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
-const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike, attending }, key ) => {
+const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike, attending }) => {
 
   return (
     <section
@@ -53,7 +53,7 @@ const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike
       <p>
         Notes for Staff:<span>{spike.notes}</span>
       </p>
-      {admins && user && admins.includes(user.email) && 
+      {admins && user && admins.includes(user.email) &&
       <section className='AdminInputs'>
         <p>Location:
           <select

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -185,9 +185,9 @@ export default class App extends Component {
   }
 
   render() {
-    const user = this.state.user;
+    const { user, admins } = this.state;
     if (!user) { return <SignIn /> }
-    if(this.state.admins.indexOf(user.email) !== -1) {
+    if(admins.indexOf(user.email) !== -1) {
       return (
         <section className="Application">
           <Header
@@ -199,7 +199,7 @@ export default class App extends Component {
           <Admin
             createSpike={(e) => this.createSpike(e)}
             spikes={this.state.spikes}
-            admins={this.state.admins}
+            admins={admins}
             updateSpike={(spike, prop, value) => this.updateSpike(spike, prop, value)}
             deleteSpike={(spike) => this.deleteSpike(spike)}
             newAdmin={(email) => this.newAdmin(email)}
@@ -232,6 +232,8 @@ export default class App extends Component {
             user={user}
             updateCount={(spike) => this.updateCount(spike)}
             assignRooms={this.assignRooms}
+            admins={this.state.admins}
+            deleteSpike={(spike) => this.deleteSpike(spike)}
           />
         </section>
       )

--- a/lib/components/Spikes.js
+++ b/lib/components/Spikes.js
@@ -6,6 +6,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 import FloorMap from './FloorMap';
 import Spike from './Spike';
+import AdminSpike from './AdminSpike';
 
 export default class Spikes extends Component {
   constructor(props) {
@@ -48,6 +49,21 @@ export default class Spikes extends Component {
           )
         }
       }
+     if(spike.createdBy === user.email) {
+       if(moment(spike.spikeDate).format('MM-DD-YYYY') === moment(dateFilter).format('MM-DD-YYYY')) {
+        return (
+          <AdminSpike
+                user={user}
+                admins={this.state.admins}
+                spike={spike}
+                key={spike.key}
+                updateSpike={this.props.updateSpike}
+                deleteSpike={this.props.deleteSpike}
+                attending={this.props.attending}
+          />
+        )
+       }
+     }
     })
   }
 


### PR DESCRIPTION
## Purpose
This PR updates the UI for the user so that they are able to see a spike if it has not yet been approved.  The user sees a modified version of the admin card so they can see the attendees list and are able to delete the spike they've created.
