### PR TITLE
Responsive admin page and style gear up form 

### DIFF
--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -104,24 +104,26 @@ export default class Admin extends Component {
         >
           {this.state.floorMap && <FloorMap rooms={roomAssignments} hideMap={()=>this.setState({ floorMap: false })}/>}
         </ReactCSSTransitionGroup>
-        <button
-          className='OpenAdminsListButton'
-          onClick={() => this.setState({ adminList: true })}
-        >
-          Admins List
-        </button>
-        <button
-          className='ShowMapButton'
-          onClick={() => this.setState({ floorMap: true })}
-        >
-          Show Map
-        </button>
-        <button
-          className='AddSpeakerButton'
-          onClick={() => this.setState({ speakerForm: true })}
-        >
-          Add Guest Speaker
-        </button>
+        <section className='AdminButtons'>
+          <button
+            className='OpenAdminsListButton'
+            onClick={() => this.setState({ adminList: true })}
+          >
+            Admins List
+          </button>
+          <button
+            className='ShowMapButton'
+            onClick={() => this.setState({ floorMap: true })}
+          >
+            Show Map
+          </button>
+          <button
+            className='AddSpeakerButton'
+            onClick={() => this.setState({ speakerForm: true })}
+          >
+            Add Guest Speaker
+          </button>
+        </section>
         <ReactCSSTransitionGroup
           transitionName='AnimateForm'
           transitionEnterTimeout={700}
@@ -130,7 +132,7 @@ export default class Admin extends Component {
           {this.state.speakerForm && <GuestSpeakerForm speaker={this.props.speaker} hideForm={()=>this.setState({ speakerForm: false })}/>}
         </ReactCSSTransitionGroup>
         <section className='SortSpikes'>
-          <p>Sort Spikes by:
+          <p className='SortSpikesTitle'>Sort Spikes by:
             <select name='all' onChange={(e)=>this.setState({ filter: e.target.value })}>
               <option value='all'>All</option>
               <option value='true'>Approved</option>

--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -18,7 +18,8 @@ export default class Admin extends Component {
       dateFilter: '',
       filter: 'all',
       floorMap: false,
-      speakerForm: false
+      speakerForm: false,
+      gearUpForm: false
     };
   }
 
@@ -100,13 +101,6 @@ export default class Admin extends Component {
 
     return (
       <section className='Admin'>
-        <ReactCSSTransitionGroup
-          transitionName='AnimateForm'
-          transitionEnterTimeout={700}
-          transitionLeaveTimeout={700}
-        >
-          {this.state.floorMap && <FloorMap rooms={roomAssignments} hideMap={()=>this.setState({ floorMap: false })}/>}
-        </ReactCSSTransitionGroup>
         <section className='AdminButtons'>
           <button
             className='OpenAdminsListButton'
@@ -126,7 +120,20 @@ export default class Admin extends Component {
           >
             Add Guest Speaker
           </button>
+          <button
+            className='AddGearUpButton'
+            onClick={() => this.setState({ gearUpForm: true })}
+          >
+            Add Gear Up
+          </button>
         </section>
+        <ReactCSSTransitionGroup
+          transitionName='AnimateForm'
+          transitionEnterTimeout={700}
+          transitionLeaveTimeout={700}
+        >
+          {this.state.floorMap && <FloorMap rooms={roomAssignments} hideMap={()=>this.setState({ floorMap: false })}/>}
+        </ReactCSSTransitionGroup>
         <ReactCSSTransitionGroup
           transitionName='AnimateForm'
           transitionEnterTimeout={700}
@@ -134,8 +141,15 @@ export default class Admin extends Component {
         >
           {this.state.speakerForm && <GuestSpeakerForm speaker={this.props.speaker} hideForm={()=>this.setState({ speakerForm: false })}/>}
         </ReactCSSTransitionGroup>
+        <ReactCSSTransitionGroup
+          transitionName='AnimateForm'
+          transitionEnterTimeout={700}
+          transitionLeaveTimeout={700}
+        >
+          {this.state.gearUpForm && <GearUpForm gearUp={this.props.gearUp} hideGearUpForm={()=>this.setState({ gearUpForm: false })}/>}
+        </ReactCSSTransitionGroup>
         <section className='SortSpikes'>
-          <p className='SortSpikesTitle'>Sort Spikes by:
+          <p className='SortOptions'>Sort Spikes by:
             <select name='all' onChange={(e)=>this.setState({ filter: e.target.value })}>
               <option value='all'>All</option>
               <option value='true'>Approved</option>

--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -25,13 +25,13 @@ const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike
           </button>
       </p>
       <ReactCSSTransitionGroup
-        transitionName='AnimateList'
+        transitionName='AnimateAttendeeList'
         transitionEnterTimeout={700}
         transitionLeaveTimeout={700}
       >
-        <div id={spike.createdAt} className='AttendeesList'>
+        <section id={spike.createdAt} className='AttendeesList'>
           <ul className='AttendeesModal'>
-            <button onClick={()=>document.getElementById(`${spike.createdAt}`).style.display = 'none'}
+            <button className='CloseAttendeeListButton' onClick={()=>document.getElementById(`${spike.createdAt}`).style.display = 'none'}
               >Close
             </button>
             {spike.attendees ?
@@ -41,7 +41,7 @@ const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike
               : <p><span>No Attendees Have Joined</span></p>
             }
           </ul>
-        </div>
+        </section>
       </ReactCSSTransitionGroup>
       <p>
         Date Submitted:<span>{moment(spike.createdAt).format('MM-DD-YYYY')}</span>

--- a/lib/components/GearUpForm.js
+++ b/lib/components/GearUpForm.js
@@ -30,28 +30,37 @@ export default class GearUpForm extends Component {
 
   render() {
     return(
-      <div>
-        <form id='GearUpForm' onSubmit={(e)=>this.createGearUp(e)}>
-          <h2>Submit a Gear Up</h2>
-          <input
-            name='title'
-            onChange={(e)=>this.setGearUpInfo(e)}
-            placeholder='title'
-          />
-          <input
-            name='description'
-            onChange={(e)=>this.setGearUpInfo(e)}
-            placeholder='description'
-          />
-          <input
-            name='link'
-            onChange={(e)=>this.setGearUpInfo(e)}
-            placeholder='link'
-          />
-          <button type='submit'>Submit</button>
-        </form>
-        <GearUp gearUp={this.props.gearUp}/>
-      </div>
+      <section className='Modal'>
+        <section id='GearUpForm'>
+          <form onSubmit={(e)=>this.createGearUp(e)}>
+            <h1 className='FormTitle GearUpTitle'>Submit a Gear Up</h1>
+            <input
+              name='title'
+              onChange={(e)=>this.setGearUpInfo(e)}
+              placeholder='Gear Up Title'
+            />
+            <textarea
+              name='description'
+              onChange={(e)=>this.setGearUpInfo(e)}
+              placeholder='Description'
+            />
+            <input
+              name='link'
+              onChange={(e)=>this.setGearUpInfo(e)}
+              placeholder='Link'
+            />
+            <section className='ButtonContainer'>
+              <button className='SubmitButton' type='submit'>Submit</button>
+              <button className='CancelButton' onClick={(e) => {
+                e.preventDefault();
+                this.props.hideGearUpForm(e)
+              }}
+              >Cancel</button>
+            </section>
+          </form>
+          <GearUp gearUp={this.props.gearUp}/>
+        </section>
+      </section>
     )
   }
 }

--- a/lib/components/GuestSpeakerForm.js
+++ b/lib/components/GuestSpeakerForm.js
@@ -49,7 +49,7 @@ export default class GuestSpeakerForm extends Component {
               onChange={(e)=>this.setSpeakerInfo(e)}
               placeholder='Link'
             />
-            <section className="ButtonContainer">
+            <section className='ButtonContainer'>
               <button className='SubmitButton' type='submit'>Submit</button>
               <button className='CancelButton' onClick={(e) => {
                 e.preventDefault();

--- a/lib/styles/main.scss
+++ b/lib/styles/main.scss
@@ -10,3 +10,4 @@
 @import 'partials/_admins';
 @import 'partials/_floor-map';
 @import 'partials/_guest-speaker';
+@import 'partials/_modals';

--- a/lib/styles/modules/_mixins.scss
+++ b/lib/styles/modules/_mixins.scss
@@ -56,5 +56,6 @@
 @mixin modal {
   background-color: rgba(0,0,0,0.9);
   overflow: auto;
+  overflow-y: scroll;
   position: fixed;
 }

--- a/lib/styles/partials/_admin-spike.scss
+++ b/lib/styles/partials/_admin-spike.scss
@@ -51,8 +51,14 @@
 .AttendeesModal {
   @include modal;
   height: 100%;
-  left: 0;
+  padding: 100px 10px 10px 10px;
+  right: 0;
   top: 0;
-  width: 100%;
+  width: 320px;
   z-index: 2;
+  span {
+    color: $light-gray-color;
+    margin-top: 50px;
+    padding: 10px 0;
+  }
 }

--- a/lib/styles/partials/_admins.scss
+++ b/lib/styles/partials/_admins.scss
@@ -10,32 +10,9 @@
   z-index: 1;
 }
 
-.AnimateList-enter {
-  opacity: 0.01;
-  width: 0px;
-}
-
-.AnimateList-enter.AnimateList-enter-active {
-  opacity: 1;
-  transition: 700ms;
-  width: 320px;
-}
-
-.AnimateList-leave {
-  opacity: 1;
-  width: 320px;
-}
-
-.AnimateList-leave.AnimateList-leave-active {
-  opacity: 0.01;
-  transition: 700ms;
-  width: 0px;
-}
-
 .OpenAdminsListButton {
   @include button-format($teal-accent, #FFF);
   margin: 20px 0 0 20px;
-  width: 120px;
 }
 
 .CloseListButton {
@@ -89,6 +66,10 @@
   }
 }
 
+.AdminButtons {
+  display: inline-block;
+}
+
 .ShowMapButton, .AddSpeakerButton {
   @include button-format($teal-accent, #FFF);
   margin-left: 10px;
@@ -97,5 +78,38 @@
 @media screen and (max-width: 770px) {
   .ShowMapButton {
     display: none;
+  }
+}
+
+@media screen and (max-width: 420px) {
+  .AdminButtons {
+    text-align: center;
+    width: 100%;
+    button {
+      padding: 10px;
+      margin: 8px;
+    }
+  }
+  .SortSpikesTitle {
+    font-size: 18px;
+  }
+}
+
+@media screen and (max-width: 375px) {
+  .AdminInputs {
+    width: 100%;
+  }
+
+  .SortSpikes {
+    float: none;
+    margin: auto;
+    margin-top: 20px;
+    width: 70%;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  .SortSpikes {
+    width: 80%;
   }
 }

--- a/lib/styles/partials/_admins.scss
+++ b/lib/styles/partials/_admins.scss
@@ -70,7 +70,7 @@
   display: inline-block;
 }
 
-.ShowMapButton, .AddSpeakerButton {
+.ShowMapButton, .AddSpeakerButton, .AddGearUpButton {
   @include button-format($teal-accent, #FFF);
   margin-left: 10px;
 }
@@ -79,19 +79,22 @@
   .ShowMapButton {
     display: none;
   }
+  .SortSpikes {
+    float: left;
+    margin: 20px;
+  }
 }
 
 @media screen and (max-width: 420px) {
   .AdminButtons {
-    text-align: center;
-    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     button {
       padding: 10px;
       margin: 8px;
+      width: 90%;
     }
-  }
-  .SortSpikesTitle {
-    font-size: 18px;
   }
 }
 
@@ -101,15 +104,18 @@
   }
 
   .SortSpikes {
-    float: none;
-    margin: auto;
-    margin-top: 20px;
-    width: 70%;
+    margin: 15px 0 0 0;
+    width: 100%;
   }
-}
 
-@media screen and (max-width: 320px) {
-  .SortSpikes {
-    width: 80%;
+  .SortOptions {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    select {
+      font-size: 20px;
+      margin: 5px 0;
+      width: 150px;
+    }
   }
 }

--- a/lib/styles/partials/_admins.scss
+++ b/lib/styles/partials/_admins.scss
@@ -22,6 +22,13 @@
   top: 15px;
 }
 
+.CloseAttendeeListButton {
+  @include button-format($teal-accent, #FFF);
+  position: absolute;
+  left: 15px;
+  top: 15px;
+}
+
 .AdminEmails {
   display: flex;
   flex-direction: column;

--- a/lib/styles/partials/_guest-speaker.scss
+++ b/lib/styles/partials/_guest-speaker.scss
@@ -1,14 +1,14 @@
 .GuestSpeaker {
-  font-family: $open-sans-font;
-  line-height: 30px;
   border: 2px solid $teal-accent;
   border-radius: 5px;
+  color: $dark-gray-color;
+  font-family: $open-sans-font;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 30px;
+  margin: 30px auto;
   text-align: center;
   width: 80%;
-  margin: 30px auto;
-  color: $dark-gray-color;
-  font-weight: bold;
-  font-size: 18px;
   h2 {
     font-size: 24px;
     margin: 10px 0;
@@ -26,8 +26,8 @@
 .SpeakerLink {
   color: $dark-gray-color;
   font-weight: bold;
-  text-decoration: none;
   padding-bottom: 5px;
+  text-decoration: none;
   &:hover {
     color: $teal-accent;
   }
@@ -35,6 +35,9 @@
 
 @media screen and (max-width: 420px) {
   .GuestSpeaker {
+    margin-top: 70px;
+    padding: 10px;
+    width: 88%;
     span {
       display: block;
     }

--- a/lib/styles/partials/_guest-speaker.scss
+++ b/lib/styles/partials/_guest-speaker.scss
@@ -33,13 +33,25 @@
   }
 }
 
-@media screen and (max-width: 420px) {
+@media screen and (max-width: 770px) {
   .GuestSpeaker {
     margin-top: 70px;
+  }
+}
+
+@media screen and (max-width: 420px) {
+  .GuestSpeaker {
+    margin-top: 80px;
     padding: 10px;
-    width: 88%;
+    width: 90%;
     span {
       display: block;
     }
+  }
+}
+
+@media screen and (max-width: 375px) {
+  .GuestSpeaker {
+    margin-top: 130px;
   }
 }

--- a/lib/styles/partials/_header.scss
+++ b/lib/styles/partials/_header.scss
@@ -55,6 +55,7 @@ header {
 @media screen and (max-width: 420px) {
   header {
     height: 390px;
+    margin-bottom: 10px;
   }
 
   .HeaderTitle {
@@ -93,10 +94,13 @@ header {
   }
 
   .AddSpikeButton {
+    display: flex;
     font-size: 20px;
-    padding: 15px;
-    margin-top: 10px;
-    margin-left: 30%;
+    justify-content: center;
+    margin: auto;
+    margin-top: 15px;
+    padding: 10px;
+    text-align: center;
     width: 120px;
   }
 }

--- a/lib/styles/partials/_modals.scss
+++ b/lib/styles/partials/_modals.scss
@@ -1,0 +1,41 @@
+// Admin email list modal
+.AnimateList-enter {
+  opacity: 0.01;
+  width: 0px;
+}
+
+.AnimateList-enter.AnimateList-enter-active {
+  opacity: 1;
+  transition: 700ms;
+  width: 320px;
+}
+
+.AnimateList-leave {
+  opacity: 1;
+  width: 320px;
+}
+
+.AnimateList-leave.AnimateList-leave-active {
+  opacity: 0.01;
+  transition: 700ms;
+  width: 0px;
+}
+
+// generic form modal
+.AnimateForm-enter {
+  opacity: 0.01;
+}
+
+.AnimateForm-enter.AnimateForm-enter-active {
+  opacity: 1;
+  transition: opacity 500ms ease-in;
+}
+
+.AnimateForm-leave {
+  opacity: 1;
+}
+
+.AnimateForm-leave.AnimateForm-leave-active {
+  opacity: 0.01;
+  transition: opacity 300ms ease-in;
+}

--- a/lib/styles/partials/_modals.scss
+++ b/lib/styles/partials/_modals.scss
@@ -21,7 +21,30 @@
   width: 0px;
 }
 
-// generic form modal
+// Attendee email list modal
+.AnimateAttendeeList-enter {
+  opacity: 0.01;
+  width: 0px;
+}
+
+.AnimateAttendeeList-enter.AnimateAttendeeList-enter-active {
+  opacity: 1;
+  transition: 700ms;
+  width: 320px;
+}
+
+.AnimateAttendeeList-leave {
+  opacity: 1;
+  width: 320px;
+}
+
+.AnimateAttendeeList-leave.AnimateAttendeeList-leave-active {
+  opacity: 0.01;
+  transition: 700ms;
+  width: 0px;
+}
+
+// Generic form modal
 .AnimateForm-enter {
   opacity: 0.01;
 }

--- a/lib/styles/partials/_proposal-form.scss
+++ b/lib/styles/partials/_proposal-form.scss
@@ -26,24 +26,6 @@ form {
   z-index: 2;
 }
 
-.AnimateForm-enter {
-  opacity: 0.01;
-}
-
-.AnimateForm-enter.AnimateForm-enter-active {
-  opacity: 1;
-  transition: opacity 500ms ease-in;
-}
-
-.AnimateForm-leave {
-  opacity: 1;
-}
-
-.AnimateForm-leave.AnimateForm-leave-active {
-  opacity: 0.01;
-  transition: opacity 300ms ease-in;
-}
-
 .FormTitle {
   color: #FFF;
   font-size: 30px;

--- a/lib/styles/partials/_proposal-form.scss
+++ b/lib/styles/partials/_proposal-form.scss
@@ -1,4 +1,4 @@
-#SpikeForm, #SpeakerForm {
+#SpikeForm, #SpeakerForm, #GearUpForm {
   align-items: center;
   background: $dark-gray-color;
   border-radius: 10px;
@@ -32,7 +32,7 @@ form {
   padding-top: 15px;
 }
 
-.SpeakerFormTitle {
+.SpeakerFormTitle, .GearUpTitle {
   margin-bottom: 10px;
   text-align: center;
 }
@@ -73,7 +73,7 @@ input[type=date] {
 }
 
 @media screen and (max-width: 770px) {
-  #SpikeForm, #SpeakerForm {
+  #SpikeForm, #SpeakerForm, #GearUpForm {
     width: 80%;
   }
   form {

--- a/lib/styles/partials/_spike.scss
+++ b/lib/styles/partials/_spike.scss
@@ -44,6 +44,6 @@
 @media screen and (max-width: 420px) {
   .SpikesTitle {
     font-size: 26px;
-    margin-top: 70px;
+    margin-top: 30px;
   }
 }


### PR DESCRIPTION
# Purpose 
Admin page is now fully responsive, checked on ipads and all mobile devices 

Made gear up form a modal 

Styled attendee email list - Wasn't able to animate it because the `<ReactCSSTransitionGroup>` needs to wrap the state of the component, but since this admin card is stateless we can't do that. Perhaps someone can look into how this can be changed, but for right now it's styled, but doesn't have sliding animation.

Added `overflow-y: scroll` to the modal, so hopefully the modal can scroll on mobile when the phone is sideways, can only test if the app is deployed with the latest changes

closes #95
closes #106 
closes #105 
