### PR TITLE
make title, description and hosts editable -- Closes #71

### DIFF
--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -1,108 +1,150 @@
-import React from 'react';
+import React, {Component} from 'react';
 import firebase from '../firebase';
 import moment from 'moment';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
-const AdminSpike = ({ admins, user, spike, createSpike, updateSpike, deleteSpike, attending }) => {
+export default class AdminSpike extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      spike: this.props.spike
+    };
+  }
 
-  return (
-    <section
-      className={spike.appr ? 'ApprovedSpike' : 'SpikeCard AdminSpikeCard'}
-      key={spike.key}
-    >
-      <p>Spike Topic:<span>{spike.title}</span></p>
-      <p>Description:<span>{spike.description}</span></p>
-      <p>Created by:<span>{spike.createdBy}</span></p>
-      <p>Spike Hosts:<span>{spike.hosts}</span></p>
-      <p>Attendees: {spike.attendees && spike.attendees.length}
-        <button
-          className='ShowAttendeesButton'
-          onClick={()=>{
+  handleEdits(e, spike, value) {
+    this.props.updateSpike(spike, value, e.target.innerHTML);
+  }
+
+  render() {
+    const {user, spike, admins, updateSpike} = this.props;
+    return (
+      <section
+        className={spike.appr ? 'ApprovedSpike' : 'SpikeCard AdminSpikeCard'}
+        key={spike.key}>
+        <p>Spike Topic:
+          <span
+            contentEditable={false}
+            onBlur={(e) => {
+              this.handleEdits(e, this.state.spike, 'title')
+            }}
+            onClick={(e) => {
+              e.target.contentEditable = 'true'
+            }}>{spike.title}
+          </span>
+        </p>
+        <p>Description:
+          <span
+            contentEditable={false}
+            onBlur={(e) => {
+              this.handleEdits(e, this.state.spike, 'description')
+            }}
+            onClick={(e) => {
+              e.target.contentEditable = 'true'
+            }}>{spike.description}
+          </span>
+        </p>
+        <p>Created by:
+          <span>{spike.createdBy}</span>
+        </p>
+        <p>Spike Hosts:
+          <span
+            contentEditable={false}
+            onBlur={(e) => {
+              this.handleEdits(e, this.state.spike, 'hosts')
+            }}
+            onClick={(e) => {
+              e.target.contentEditable = 'true'
+            }}>{spike.hosts}
+          </span>
+        </p>
+        <p>Attendees: {spike.attendees && spike.attendees.length}
+          <button
+            className='ShowAttendeesButton'
+            onClick={() => {
             document.getElementById(`${spike.createdAt}`).style.display = 'block'
-          }}
-          >
+          }}>
             See all
           </button>
-      </p>
-      <ReactCSSTransitionGroup
-        transitionName='AnimateAttendeeList'
-        transitionEnterTimeout={700}
-        transitionLeaveTimeout={700}
-      >
-        <section id={spike.createdAt} className='AttendeesList'>
-          <ul className='AttendeesModal'>
-            <button className='CloseAttendeeListButton' onClick={()=>document.getElementById(`${spike.createdAt}`).style.display = 'none'}
-              >Close
-            </button>
-            {spike.attendees ?
-              spike.attendees.map((attendee, index) => {
-                return <li className='attendee' key={index}><span>{attendee}</span></li>
-              })
-              : <p><span>No Attendees Have Joined</span></p>
-            }
-          </ul>
-        </section>
-      </ReactCSSTransitionGroup>
-      <p>
-        Date Submitted:<span>{moment(spike.createdAt).format('MM-DD-YYYY')}</span>
-      </p>
-      <p>
-        Spike Session Date:
-        <span>{moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
-      </p>
-      <p>
-        Notes for Staff:<span>{spike.notes}</span>
-      </p>
-      {admins && user && admins.includes(user.email) &&
-      <section className='AdminInputs'>
-        <p>Location:
-          <label htmlFor='DropdownSelect' aria-label='Location select dropdown'>
-            <select
-              className='DropdownSelect'
-              name='location'
-              onChange={(e)=>updateSpike(spike, 'location', e.target.value)}
-              value={spike.location}
-            >
-              <option value='none'>None Assigned</option>
-              <option value='Classroom A'>Classroom A</option>
-              <option value='Classroom B'>Classroom B</option>
-              <option value='Classroom C'>Classroom C</option>
-              <option value='Classroom D'>Classroom D</option>
-              <option value='Classroom E'>Classroom E</option>
-              <option value='Classroom F'>Classroom F</option>
-              <option value='Classroom G'>Classroom G</option>
-              <option value='Classroom H'>Classroom H</option>
-              <option value='Grand Room'>Grand Room</option>
-              <option value='Vault Study'>Vault Study</option>
-            </select>
-          </label>
         </p>
-        <p>Status:
-          <label htmlFor='DropdownSelect' aria-label='Spike status dropdown'>
-            <select
-              className='DropdownSelect'
-              name='approval'
-              onChange={(e)=>updateSpike(spike, 'appr', JSON.parse(e.target.value))}
-              value={spike.appr}
-              disabled={!spike.location}
-            >
-              <option value='false'>Pending</option>
-              <option value='true'>Approved</option>
-            </select>
-          </label>
-        </p>
-      </section>
-      }
-      <button
-        className='DeleteButton'
-        onClick={(e)=> {
-          e.preventDefault()
-          deleteSpike(spike)
-        }}>
-        Delete
-      </button>
-    </section>
-  )
+        <ReactCSSTransitionGroup
+          transitionName='AnimateAttendeeList'
+          transitionEnterTimeout={700}
+          transitionLeaveTimeout={700}>
+          <section id={spike.createdAt} className='AttendeesList'>
+            <ul className='AttendeesModal'>
+              <button
+                className='CloseAttendeeListButton'
+                onClick={() => document.getElementById(`${spike.createdAt}`).style.display = 'none'}>Close
+              </button>
+              {spike.attendees
+                ? spike.attendees.map((attendee, index) => {
+                    return <li className='attendee' key={index}>
+                      <span>{attendee}</span>
+                    </li>
+                  })
+                : <p>
+                  <span>No Attendees Have Joined</span>
+                </p>
 }
-
-export default AdminSpike;
+            </ul>
+          </section>
+        </ReactCSSTransitionGroup>
+        <p>
+          Date Submitted:<span>{moment(spike.createdAt).format('MM-DD-YYYY')}</span>
+        </p>
+        <p>
+          Spike Session Date:
+          <span>{moment(spike.spikeDate).format('MM-DD-YYYY')}</span>
+        </p>
+        <p>
+          Notes for Staff:<span>{spike.notes}</span>
+        </p>
+        {admins && user && admins.includes(user.email) && <section className='AdminInputs'>
+          <p>Location:
+            <label htmlFor='DropdownSelect' aria-label='Location select dropdown'>
+              <select
+                className='DropdownSelect'
+                name='location'
+                onChange={(e) => updateSpike(spike, 'location', e.target.value)}
+                value={spike.location}>
+                <option value='none'>None Assigned</option>
+                <option value='Classroom A'>Classroom A</option>
+                <option value='Classroom B'>Classroom B</option>
+                <option value='Classroom C'>Classroom C</option>
+                <option value='Classroom D'>Classroom D</option>
+                <option value='Classroom E'>Classroom E</option>
+                <option value='Classroom F'>Classroom F</option>
+                <option value='Classroom G'>Classroom G</option>
+                <option value='Classroom H'>Classroom H</option>
+                <option value='Grand Room'>Grand Room</option>
+                <option value='Vault Study'>Vault Study</option>
+              </select>
+            </label>
+          </p>
+          <p>Status:
+            <label htmlFor='DropdownSelect' aria-label='Spike status dropdown'>
+              <select
+                className='DropdownSelect'
+                name='approval'
+                onChange={(e) => updateSpike(spike, 'appr', JSON.parse(e.target.value))}
+                value={spike.appr}
+                disabled={!spike.location}>
+                <option value='false'>Pending</option>
+                <option value='true'>Approved</option>
+              </select>
+            </label>
+          </p>
+        </section>
+}
+        <button
+          className='DeleteButton'
+          onClick={(e) => {
+            e.preventDefault()
+            deleteSpike(spike)
+          }}>
+          Delete
+        </button>
+      </section>
+    )
+  }
+}

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -253,6 +253,7 @@ export default class App extends Component {
             createSpike={(e) => this.createSpike(e)}
             spikes={this.state.spikes}
             user={user}
+            updateSpike={(spike, prop, value) => this.updateSpike(spike, prop, value)}
             updateCount={(spike) => this.updateCount(spike)}
             assignRooms={this.assignRooms}
             admins={this.state.admins}


### PR DESCRIPTION
## Purpose
This PR gives admins, or users viewing their own spike (before it has been approved) the ability to edit the title, description and hosts fields.  onBlur they are updated in the DB.

## Approach
Had to make the admin-spike a class-component and create a method that takes the prop, spike and new value and calls our updateSpike function.  

## Pre-merge TODOS:
None - this is ready to merge pending code review