### PR TITLE
Format dates

### DIFF
--- a/lib/components/AdminSpike.js
+++ b/lib/components/AdminSpike.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 export default class AdminSpike extends Component {
+
   constructor(props) {
     super(props);
     this.state = {

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -129,6 +129,7 @@ export default class App extends Component {
 
   createSpike(e) {
     e.preventDefault();
+    const reformattedDate = moment(e.target.spikeDate.value).format('l');
     const user = this.state.user;
     let { title, description, spikeDate, hosts, notes } = e.target;
     if (title.value && description.value && spikeDate.value) {
@@ -141,7 +142,7 @@ export default class App extends Component {
         createdBy: this.sanitizeInput(user.email),
         hosts: this.sanitizeInput(hosts.value),
         attendees: [],
-        spikeDate: new Date(spikeDate.value).getTime(),
+        spikeDate: new Date(reformattedDate).getTime(),
         notes: this.sanitizeInput(notes.value)
       };
       reference.push(spike);


### PR DESCRIPTION
## Purpose
This PR fixes the issue where our dates were off by a day.  This had to do with the UTC offset.  

## Approach
Our date was coming from the HTML 5 element as YYYY-MM-DD and when creating a new Date from that it was creating a date in UTC tz.  I used Moment to reformat the date into MM-DD-YYYY and the Date object creates this with UTC offset in mind.

## TODOs
None - this code is ready to merge pending code review