### PR TITLE
remove width on leave button

### DIFF
--- a/lib/styles/partials/_buttons-dropdowns.scss
+++ b/lib/styles/partials/_buttons-dropdowns.scss
@@ -131,8 +131,9 @@ select {
 }
 
 .JoinButton {
-  @include button-format($darker-accent, #FFF, 70px);
+  @include button-format($darker-accent, #FFF);
   margin-top: auto;
+  padding: 5px 10px;
 }
 
 @media screen and (max-width: 420px) {


### PR DESCRIPTION
# Purpose 

Remove width on the Join/Leave button so the button looks normal on mobile 

closes #134 