### PR TITLE
Render spikes on the first load of the page - Closes #137

### DIFF
--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -20,15 +20,23 @@ export default class Admin extends Component {
       filter: 'all',
       floorMap: false,
       speakerForm: false,
-      gearUpForm: false
+      gearUpForm: false,
+      spikes: null
     };
   }
 
-  componentWillReceiveProps() {
-    const { spikes } = this.props;
+  componentDidMount() {
+    this.setDatesAndSpikes(this.props.spikes);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setDatesAndSpikes(nextProps.spikes);
+  }
+
+  setDatesAndSpikes(spikes) {
     if (spikes.length) {
-      let dateOptions = this.dateOptions(this.props.spikes);
-      this.setState({ dateFilter: dateOptions[0].props.value});
+      let dateOptions = this.dateOptions(spikes)
+      this.setState({ dateFilter: dateOptions[0].props.value, spikes })
     }
   }
 
@@ -87,13 +95,12 @@ export default class Admin extends Component {
     	deleteSpike,
     	newAdmin,
     	removeAdmin,
-    	spikes,
     	updateSpike,
     	user,
       assignRooms,
       sanitizeInput
     } = this.props;
-
+    const { spikes } = this.state;
 
     let allSpikes = this.filterSpikes(spikes)
 

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -24,11 +24,23 @@ export default class App extends Component {
     };
   }
 
+  
+  componentWillMount () {
+    this.fetchAdmins();
+    this.fetchSpeaker();
+    this.fetchGearup();
+    this.fetchSpikes();
+  }
+  
+
   componentDidMount() {
     firebase.auth().onAuthStateChanged((newUser) => {
       this.newUser(newUser);
     });
+    
+  }
 
+  fetchSpikes() {
     reference.limitToLast(100).on('value', (snapshot) => {
       let oneDay = 1000*60*60*24;
       let oneYear = 1000*60*60*24*365;
@@ -47,6 +59,9 @@ export default class App extends Component {
       });
       this.setAttending();
     });
+  }
+
+  fetchAdmins() {
     adminReference.limitToLast(100).on('value', (snapshot) => {
       admins = snapshot.val() || {};
       this.setState({
@@ -54,6 +69,9 @@ export default class App extends Component {
       });
       admins = invert(admins);
     });
+  }
+
+  fetchSpeaker() {
     speakerReference.limitToLast(1).on('value', (snapshot) => {
       const speakers = snapshot.val() || {};
       map(speakers, (val, key) => {
@@ -63,6 +81,9 @@ export default class App extends Component {
         });
       });
     });
+  }
+
+  fetchGearup() {
     gearUpReference.limitToLast(1).on('value', (snapshot) => {
       const gearups = snapshot.val() || {};
       this.setState({
@@ -200,7 +221,9 @@ export default class App extends Component {
   }
 
   render() {
-    const { user, admins } = this.state;
+
+    const { user, admins, spikes } = this.state;
+
     if (!user) { return <SignIn />}
     if(admins.indexOf(user.email) !== -1) {
       return (
@@ -252,7 +275,7 @@ export default class App extends Component {
           <Spikes
             attending={this.state.attending}
             createSpike={(e) => this.createSpike(e)}
-            spikes={this.state.spikes}
+            spikes={spikes}
             user={user}
             updateSpike={(spike, prop, value) => this.updateSpike(spike, prop, value)}
             updateCount={(spike) => this.updateCount(spike)}

--- a/lib/components/Spike.js
+++ b/lib/components/Spike.js
@@ -3,6 +3,7 @@ import firebase from '../firebase';
 import moment from 'moment';
 
 const Spike = ({ spike, createSpike, updateCount, toggleForm, user, attending }, key, admin ) => {
+
   if (spike) {
     return (
       <section className='SpikeCard' key={key}>

--- a/lib/components/Spikes.js
+++ b/lib/components/Spikes.js
@@ -10,10 +10,11 @@ import AdminSpike from './AdminSpike';
 
 export default class Spikes extends Component {
   constructor(props) {
-    super();
+    super(props);
     this.state = {
       dateFilter: '',
       floorMap: false,
+      spikes: null
     };
   }
 
@@ -46,12 +47,18 @@ export default class Spikes extends Component {
     return classRooms;
   }
 
+  componentDidMount() {
+    this.setDatesAndSpikes(this.props.spikes);
+  }
 
-  componentWillReceiveProps() {
-    const { spikes } = this.props
+  componentWillReceiveProps(nextProps) {
+    this.setDatesAndSpikes(nextProps.spikes);
+  }
+
+  setDatesAndSpikes(spikes) {
     if (spikes.length) {
-      let dateOptions = this.dateOptions(this.props.spikes)
-      this.setState({ dateFilter: dateOptions[0].props.value})
+      let dateOptions = this.dateOptions(spikes)
+      this.setState({ dateFilter: dateOptions[0].props.value, spikes })
     }
   }
 
@@ -60,7 +67,7 @@ export default class Spikes extends Component {
     const { dateFilter } = this.state;
     return map(spikes, (spike) => {
       if(spike.appr) {
-          if(moment(spike.spikeDate).format('MM-DD-YYYY') === moment(dateFilter).format('MM-DD-YYYY')) {
+        if(moment(spike.spikeDate).format('MM-DD-YYYY') === moment(dateFilter).format('MM-DD-YYYY')) {
           return (
             <Spike
               spike={spike}
@@ -72,7 +79,7 @@ export default class Spikes extends Component {
           )
         }
       }
-     if(spike.createdBy === user.email) {
+     if(spike.createdBy === user.email && !spike.appr) {
        if(moment(spike.spikeDate).format('MM-DD-YYYY') === moment(dateFilter).format('MM-DD-YYYY')) {
         return (
           <AdminSpike
@@ -91,7 +98,7 @@ export default class Spikes extends Component {
   }
 
   render() {
-    const { spikes, assignRooms } = this.props
+    const { spikes, assignRooms } = this.state
 
     let allSpikes = this.filterSpikes(spikes)
 


### PR DESCRIPTION
## Purpose
This PR fixes the issue where spikes are not rendered to the page the first time a user visits.  Now when a user or admin log into the page for the very first time, and each subsequent visit, all spikes and info are rendered to the page. 

## Approach
Abstracted our firebase calls out into their own functions.  Fetching the admins, spikes, gearup and speaker does not happen until a user is received back from firebase.  Updated the spikes and admin components to track the spikes rec'd in their own state.  Abstracted our function that updates the date filter and spikes and call it on `componentDidMount` and `componentWillReceiveProps`  Updated functions and render methods accordingly.

## Pre-merge TODOs
None, this PR is ready to merge pending code review.