### PR TITLE
Tweak styling for links to guest speaker info and gearup markdown - Closes #146

### DIFF
--- a/lib/components/GuestSpeaker.js
+++ b/lib/components/GuestSpeaker.js
@@ -7,8 +7,8 @@ const GuestSpeaker = ({ speaker, updateSpeakerAttendees, admins, user }) => {
         <h2>Our Guest Speaker This Week: </h2>
         <p className='SpeakerName'>Guest Speaker:<span>{speaker[0].name}</span></p>
         <p className='SpeakerDescription'>About the speaker:<span>{speaker[0].description}</span></p>
-        <a className='FridayLink' target="_blank" href={speaker[0].link}>Click here for info on this speaker</a>
         <p>Guest Speaker Attendees Count: <span>{speaker[0].attendees ? speaker[0].attendees.length : 0}</span></p>
+        <a className='FridayLink' target="_blank" href={speaker[0].link}>Click here for info on this speaker</a>
         <div>
           {admins && !admins.includes(user.email) &&
             <button

--- a/lib/components/GuestSpeaker.js
+++ b/lib/components/GuestSpeaker.js
@@ -7,7 +7,7 @@ const GuestSpeaker = ({ speaker, updateSpeakerAttendees, admins, user }) => {
         <h2>Our Guest Speaker This Week: </h2>
         <p className='SpeakerName'>Guest Speaker:<span>{speaker[0].name}</span></p>
         <p className='SpeakerDescription'>About the speaker:<span>{speaker[0].description}</span></p>
-        <p>Guest Speaker Attendees Count: <span>{speaker[0].attendees ? speaker[0].attendees.length : 0}</span></p>
+        <p className="Count">Guest Speaker Attendees Count: <span>{speaker[0].attendees ? speaker[0].attendees.length : 0}</span></p>
         <a className='FridayLink' target="_blank" href={speaker[0].link}>Click here for info on this speaker</a>
         <div>
           {admins && !admins.includes(user.email) &&

--- a/lib/styles/partials/_buttons-dropdowns.scss
+++ b/lib/styles/partials/_buttons-dropdowns.scss
@@ -142,8 +142,8 @@ select {
 }
 
 .AttendingSpeakerButton {
-  margin: 5px 0 15px 0;
-  width: 100px;
+  font-size: 18px;
+  margin: 10px 0 15px 0;
 }
 
 #SpikeStatusSort {

--- a/lib/styles/partials/_guest-speaker-and-gearup.scss
+++ b/lib/styles/partials/_guest-speaker-and-gearup.scss
@@ -8,6 +8,7 @@
   font-weight: bold;
   line-height: 30px;
   margin: 30px auto;
+  padding-bottom: 10px;
   text-align: center;
   width: 80%;
   h2 {
@@ -25,15 +26,20 @@
 }
 
 .FridayLink {
-  color: $dark-gray-color;
+  @include button-format ($darker-accent, #FFF, $width: null, $size: 18px)
   font-weight: bold;
+  margin: 5px 0;
+  padding: 2px 5px;
   text-decoration: none;
-  &:hover {
-    color: $teal-accent;
+}
+
+@media screen and (max-width: 375px) {
+  .FridayLink {
+    font-size: 18px;
   }
 }
 
-@media screen and (max-width: 420px) {
+@media screen and (max-width: 410px) {
   .GuestSpeaker,
   .GearUp {
     margin-top: 40px;

--- a/lib/styles/partials/_guest-speaker-and-gearup.scss
+++ b/lib/styles/partials/_guest-speaker-and-gearup.scss
@@ -18,6 +18,9 @@
   p {
     margin: 5px 0;
   }
+  .Count {
+    margin-bottom: 15px;
+  }
   span {
     color: darken($teal-accent, 16%);
     letter-spacing: .03em;
@@ -26,16 +29,17 @@
 }
 
 .FridayLink {
-  @include button-format ($darker-accent, #FFF, $width: null, $size: 18px)
-  font-weight: bold;
+  @include button-format ($darker-accent, #FFF, $size: 18px)
+  height: 30px;
   margin: 5px 0;
-  padding: 2px 5px;
+  padding: 2px 10px;
   text-decoration: none;
 }
 
 @media screen and (max-width: 375px) {
   .FridayLink {
-    font-size: 18px;
+    font-size: 16px;
+    padding: 2px 7px;
   }
 }
 
@@ -48,5 +52,11 @@
     span {
       display: block;
     }
+  }
+}
+
+@media screen and (min-width: 760px) {
+  .FridayLink {
+    margin: 15px 0;
   }
 }


### PR DESCRIPTION
## Purpose
This PR adjusts the background and font colors of the guest speaker info link and the gear up markdown link for a better UX.

## Approach
I styled these elements in the same manner as regular buttons on the page for consistency.  I first attempted to merely change the font color to our teal accent, but the link still was not differentiated enough from the rest of the text, thus I added background and button styling to make links more distinct.  I also adjusted some padding and margins of those elements and some of their neighboring elements for all screen sizes.  In addition, to maintain visual consistency between the gear up and guest speaker components I moved the link to guest speaker to the bottom of the containing div.

## Pre-merge TODOs
None, this PR is ready to merge pending code review.