### PR TITLE
remove trailing comma in firebase rules

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -15,6 +15,6 @@
   "gearUp": {
     ".read": "auth != null",
     ".write": "auth != null"
-  },
+  }
  }
 }


### PR DESCRIPTION
### Purpose
this PR removes a trailing comma in the db rules that was causing issues with deploying to firebase.