### PR TITLE
remove pete and make ilana super admin

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -10,7 +10,7 @@
   },
   "admins": {
     ".read": "auth != null",
-    ".write": "auth.email !== 'peterspringer829@gmail.com'"
+    ".write": "auth.email !== 'ilana.corson@gmail.com'"
   },
   "gearUp": {
     ".read": "auth != null",

--- a/lib/components/Admin.js
+++ b/lib/components/Admin.js
@@ -112,7 +112,7 @@ export default class Admin extends Component {
           {admin}
           <button
             className='DeleteAdminButton'
-            hidden={user.email !== 'peterspringer829@gmail.com'}
+            hidden={user.email !== 'ilana.corson@gmail.com'}
             onClick={()=>removeAdmin(admin)}>
             X
           </button>

--- a/lib/components/AdminList.js
+++ b/lib/components/AdminList.js
@@ -8,7 +8,7 @@ const AdminList = ({ toggleList, allAdmins, newAdmin, user }) => {
       <form className='AddAdminForm' onSubmit={(e) => newAdmin(e)}>
         <label htmlFor='newAdmin' aria-label='email' title='email'>
           <input
-            hidden={user.email !== 'peterspringer829@gmail.com'}
+            hidden={user.email !== 'ilana.corson@gmail.com'}
             id='newAdmin'
             name='email'
             placeholder='name@email.com'
@@ -17,7 +17,7 @@ const AdminList = ({ toggleList, allAdmins, newAdmin, user }) => {
         </label>
         <label htmlFor='AdminSubmitButton' aria-label='submit button' title='submit'>
           <input
-            hidden={user.email !== 'peterspringer829@gmail.com'}
+            hidden={user.email !== 'ilana.corson@gmail.com'}
             className='AdminSubmitButton'
             type='submit'
           />


### PR DESCRIPTION
### Purpose
This PR changes the super-admin (control over adding/removing other admins) from Pete over to Ilana.  

### Approach
Removed Pete's email from codebase and put in my own, tested as working then changed mine over to Ilana. 

This is not a very good way to be handling authentication for this role.  We should add another role in Firebase for a super-admin and then render our conditionals, and configure our database write rules for this. 

For now, it should get Ilana to a point where she can add and remove admins as needed. 